### PR TITLE
Fix for #102 - Use SLF4J in lieu of the legacy Liferay Logger

### DIFF
--- a/src/main/resources/templates/7.2/Portlet_XXXXSVC_Indexer.java.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXSVC_Indexer.java.ftl
@@ -12,8 +12,6 @@ import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.BaseIndexer;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
@@ -40,6 +38,9 @@ import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ${capFirstModel} Indexer
@@ -238,7 +239,7 @@ public class ${capFirstModel}Indexer extends BaseIndexer<${capFirstModel}> {
 	@Reference
 	protected ${capFirstModel}LocalService _${uncapFirstModel}LocalService;
 
-	private static final Log _log = LogFactoryUtil.getLog(
+	private static final Logger _log = LoggerFactory.getLogger(
 		${capFirstModel}Indexer.class);
 
 	@Reference(target = "(model.class.name=${packageName}.model.${capFirstModel})")

--- a/src/main/resources/templates/7.2/Portlet_XXXXSVC_LocalServiceImpl.java.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXSVC_LocalServiceImpl.java.ftl
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -74,6 +72,9 @@ import javax.portlet.PortletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The implementation of the ${capFirstModel} local service.
@@ -1274,7 +1275,7 @@ public class ${capFirstModel}LocalServiceImpl extends ${capFirstModel}LocalServi
 		WorkflowConstants.STATUS_SCHEDULED
 	};
 
-	private static Log _log = LogFactoryUtil.getLog(
+	private static Logger _log = LoggerFactory.getLogger(
 		${capFirstModel}LocalServiceImpl.class);
 
 	@Reference

--- a/src/main/resources/templates/7.2/Portlet_XXXXSVC_WorkflowManager.java.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXSVC_WorkflowManager.java.ftl
@@ -10,8 +10,6 @@ package ${packageName}.service.workflow;
 
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.WorkflowInstanceLink;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalServiceUtil;
@@ -26,6 +24,9 @@ import ${packageName}.model.${capFirstModel};
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ${capFirstModel} Workflow Utility class
@@ -361,7 +362,7 @@ public class ${capFirstModel}WorkflowManager {
 			user.getCompanyId(), scorpGroupId, _className, classPK);
 	}
 
-	private static Log _log = LogFactoryUtil.getLog(
+	private static Logger _log = LoggerFactory.getLogger(
 		${capFirstModel}WorkflowManager.class);
 
 }

--- a/src/main/resources/templates/7.2/Portlet_XXXXSVC_build.gradle.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXSVC_build.gradle.ftl
@@ -50,6 +50,7 @@ dependencies {
 	compile group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	compile group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compile group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly group: 'org.slf4j', name: 'slf4j-api', version: '1.7.26'
 	compile project(":${dashcaseProjectName}-api")
 }
 

--- a/src/main/resources/templates/7.2/Portlet_XXXXWEB_AdminCrudMVCActionCommand.java.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXWEB_AdminCrudMVCActionCommand.java.ftl
@@ -10,8 +10,6 @@ package ${packageName}.web.portlet.action;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageEntryFormProcessor;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.TrashedModel;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -45,6 +43,9 @@ import javax.portlet.ActionResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author ${damascus_author}
@@ -274,7 +275,7 @@ public class ${capFirstModel}AdminCrudMVCActionCommand extends BaseMVCActionComm
 		_${uncapFirstModel}Service = ${uncapFirstModel}Service;
 	}
 
-	private static Log _log = LogFactoryUtil.getLog(
+	private static Logger _log = LoggerFactory.getLogger(
 		${capFirstModel}AdminCrudMVCActionCommand.class);
 
 	@Reference

--- a/src/main/resources/templates/7.2/Portlet_XXXXWEB_AssetRenderer.java.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXWEB_AssetRenderer.java.ftl
@@ -13,8 +13,6 @@ import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.model.BaseJSPAssetRenderer;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -43,6 +41,9 @@ import javax.portlet.PortletURL;
 import javax.portlet.WindowState;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Asset Renderer
@@ -313,7 +314,7 @@ public class ${capFirstModel}AssetRenderer
 		}
 	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
+	private static final Logger _log = LoggerFactory.getLogger(
 		${capFirstModel}AssetRenderer.class);
 
 	private AssetDisplayPageFriendlyURLProvider

--- a/src/main/resources/templates/7.2/Portlet_XXXXWEB_AssetRendererFactory.java.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXWEB_AssetRendererFactory.java.ftl
@@ -12,8 +12,6 @@ import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.model.BaseAssetRendererFactory;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
@@ -38,6 +36,9 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ${capFirstModel} Asset Renderer Factory
@@ -181,7 +182,7 @@ public class ${capFirstModel}AssetRendererFactory
 		_servletContext = servletContext;
 	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
+	private static final Logger _log = LoggerFactory.getLogger(
 		${capFirstModel}AssetRendererFactory.class);
 
 	@Reference

--- a/src/main/resources/templates/7.2/Portlet_XXXXWEB_ConfigurationAction.java.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXWEB_ConfigurationAction.java.ftl
@@ -9,8 +9,6 @@ package ${packageName}.web.portlet.action;
 
 import aQute.bnd.annotation.metatype.Configurable;
 
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.servlet.SessionMessages;
@@ -33,6 +31,9 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Modified;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ${capFirstModel} Configuraion Aciton
@@ -152,7 +153,7 @@ public class ${capFirstModel}ConfigurationAction extends DefaultConfigurationAct
 		return valid;
 	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
+	private static final Logger _log = LoggerFactory.getLogger(
 		${capFirstModel}ConfigurationAction.class);
 
 	private volatile ${capFirstModel}Configuration _${uncapFirstModel}Configuration;

--- a/src/main/resources/templates/7.2/Portlet_XXXXWEB_CrudMVCActionCommand.java.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXWEB_CrudMVCActionCommand.java.ftl
@@ -10,8 +10,6 @@ package ${packageName}.web.portlet.action;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageEntryFormProcessor;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.TrashedModel;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -45,6 +43,9 @@ import javax.portlet.ActionResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author ${damascus_author}
@@ -274,7 +275,7 @@ public class ${capFirstModel}CrudMVCActionCommand extends BaseMVCActionCommand {
 		_${uncapFirstModel}Service = ${uncapFirstModel}Service;
 	}
 
-	private static Log _log = LogFactoryUtil.getLog(
+	private static Logger _log = LoggerFactory.getLogger(
 		${capFirstModel}CrudMVCActionCommand.class);
 
 	@Reference

--- a/src/main/resources/templates/7.2/Portlet_XXXXWEB_DisplayContext.java.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXWEB_DisplayContext.java.ftl
@@ -11,8 +11,6 @@ import com.liferay.portal.kernel.dao.search.DisplayTerms;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.dao.search.SearchContainerResults;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
@@ -41,6 +39,9 @@ import javax.portlet.PortletException;
 import javax.portlet.PortletURL;
 
 import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ${capFirstModel} Display Context
@@ -174,7 +175,7 @@ public class ${capFirstModel}DisplayContext {
 		return _searchContainer;
 	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
+	private static final Logger _log = LoggerFactory.getLogger(
 		${capFirstModel}DisplayContext.class);
 
 	private final HttpServletRequest _httpServletRequest;

--- a/src/main/resources/templates/7.2/Portlet_XXXXWEB_ViewHelper.java.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXWEB_ViewHelper.java.ftl
@@ -10,8 +10,6 @@ package ${packageName}.web.util;
 import com.liferay.portal.kernel.dao.search.DisplayTerms;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.dao.search.SearchContainerResults;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
@@ -40,6 +38,9 @@ import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 
 import org.osgi.service.component.annotations.Component;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * View Helper
@@ -276,6 +277,6 @@ public class ${capFirstModel}ViewHelper {
 		return false;
 	}
 
-	private static Log _log = LogFactoryUtil.getLog(${capFirstModel}ViewHelper.class);
+	private static Logger _log = LoggerFactory.getLogger(${capFirstModel}ViewHelper.class);
 
 }

--- a/src/main/resources/templates/7.2/Portlet_XXXXWEB_build.gradle.ftl
+++ b/src/main/resources/templates/7.2/Portlet_XXXXWEB_build.gradle.ftl
@@ -44,6 +44,7 @@ dependencies {
 	compileOnly group: "jstl", name: "jstl", version: "1.2"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly group: 'org.slf4j', name: 'slf4j-api', version: '1.7.26'
 	compileOnly project(":${dashcaseProjectName}-api")
 	compileOnly project(":${dashcaseProjectName}-service")
 }


### PR DESCRIPTION
For the 7.2 templates, replaces the use of Liferay logger with the SLF4J logger.