### PR TITLE
Fix for #104 - Application fieldsName should be optional

### DIFF
--- a/src/main/java/com/liferay/damascus/cli/json/Application.java
+++ b/src/main/java/com/liferay/damascus/cli/json/Application.java
@@ -42,7 +42,7 @@ public class Application {
     @JsonProperty(required = true)
     public Asset asset = null;
 
-    @JsonProperty(required = true)
+    @JsonProperty
     public String fieldsName = null;
 
     @JsonProperty(required = true)

--- a/src/main/resources/templates/7.0/base.json
+++ b/src/main/resources/templates/7.0/base.json
@@ -20,7 +20,6 @@
         "generateActivity": "true",
         "trash":"true"
       },
-      "fieldsName" : "${damascus.projectName}s",
       "fields": [
         {
           "type": "com.liferay.damascus.cli.json.fields.Long",

--- a/src/main/resources/templates/7.1/base.json
+++ b/src/main/resources/templates/7.1/base.json
@@ -22,7 +22,6 @@
         "advancedSearch": "true",
         "exportExcel": "true"
       },
-      "fieldsName" : "${damascus.projectName}s",
       "fields": [
         {
           "type": "com.liferay.damascus.cli.json.fields.Long",

--- a/src/main/resources/templates/7.2/base.json
+++ b/src/main/resources/templates/7.2/base.json
@@ -22,7 +22,6 @@
         "advancedSearch": "true",
         "exportExcel": "true"
       },
-      "fieldsName" : "${damascus.projectName}s",
       "fields": [
         {
           "type": "com.liferay.damascus.cli.json.fields.Long",


### PR DESCRIPTION
Removes the required attribute on fieldsName in the Application class and removes the fieldsName value from the starter base.json templates.

It still exists if a template uses it, just not required to be part of a base.json for a successful create command.